### PR TITLE
Updated AR activities to handle add item errors

### DIFF
--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARFromCraftARActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARFromCraftARActivity.java
@@ -146,12 +146,12 @@ public class ARFromCraftARActivity extends CraftARActivity implements CraftARSea
                 // Cast the found item to an AR item
                 CraftARItemAR myARItem = (CraftARItemAR)item;
                 // Add content to the tracking SDK and start AR experience
-                try {
-                    mTracking.addItem(myARItem);
+                CraftARError error = mTracking.addItem(myARItem);
+                if (error == null) {
                     mTracking.startTracking();
                     mScanningLayout.setVisibility(View.GONE);
-                } catch (CraftARSDKException e) {
-                    e.printStackTrace();
+                } else {
+                    Log.e(TAG, error.getErrorMessage());
                 }
 
             }

--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARProgrammaticallyActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARProgrammaticallyActivity.java
@@ -154,24 +154,23 @@ public class ARProgrammaticallyActivity extends CraftARActivity implements Craft
 				// Cast the found item to an AR item
 				CraftARItemAR myARItem = (CraftARItemAR)item;
 				// Add content to the tracking SDK and start AR experience
-				try {
 
-					// We create a CraftARContentImage programmatically from a resource stored in the SD card.
-					String imageUrl = getApplicationContext().getExternalFilesDir(null) + "/ar_programmatically_content.png";
-					CraftARContentImage myImage = new CraftARContentImage(imageUrl);
+				// We create a CraftARContentImage programmatically from a resource stored in the SD card.
+				String imageUrl = getApplicationContext().getExternalFilesDir(null) + "/ar_programmatically_content.png";
+				CraftARContentImage myImage = new CraftARContentImage(imageUrl);
 
-					// This will make the content to be scaled to match the edges of the reference image. This doesn't keep the aspect ratio of the content.
-					myImage.setWrapMode(CraftARContent.ContentWrapMode.WRAP_MODE_SCALE_FILL);
+				// This will make the content to be scaled to match the edges of the reference image. This doesn't keep the aspect ratio of the content.
+				myImage.setWrapMode(CraftARContent.ContentWrapMode.WRAP_MODE_SCALE_FILL);
 
-					// Add the content to the AR item
-					myARItem.addContent(myImage);
+				// Add the content to the AR item
+				myARItem.addContent(myImage);
 
-					// Add the item to the tracking and start tracking.
-					mTracking.addItem(myARItem);
+				CraftARError error = mTracking.addItem(myARItem);
+				if (error == null) {
 					mTracking.startTracking();
 					mScanningLayout.setVisibility(View.GONE);
-				} catch (CraftARSDKException e) {
-					e.printStackTrace();
+				} else {
+					Log.e(TAG, error.getErrorMessage());
 				}
 
 			}

--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/OnDeviceARActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/OnDeviceARActivity.java
@@ -28,6 +28,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.craftar.CraftARActivity;
+import com.craftar.CraftARError;
 import com.craftar.CraftARItem;
 import com.craftar.CraftARItemAR;
 import com.craftar.CraftAROnDeviceCollection;
@@ -94,13 +95,9 @@ public class OnDeviceARActivity extends CraftARActivity {
             CraftARItem item = mCollection.getItem(itemUUID);
             if(item.isAR()){
                 CraftARItemAR itemAR = (CraftARItemAR)item;
-                try {
-                    // Add the item to the tracking
-                    Log.d(TAG, "Adding item "+item.getItemName()+" for tracking");
-                    mTracking.addItem(itemAR);
-                } catch (CraftARSDKException e) {
-                    showToast(e.getMessage(),Toast.LENGTH_SHORT);
-                    e.printStackTrace();
+                CraftARError error = mTracking.addItem(itemAR);
+                if (error != null) {
+                    showToast(error.getErrorMessage(), Toast.LENGTH_SHORT);
                 }
             }
         }


### PR DESCRIPTION
The new version of the SDK does not throw exception upon addItem but returns an error if something failed.