### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARFromCraftARActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARFromCraftARActivity.java
@@ -46,10 +46,10 @@ public class ARFromCraftARActivity extends CraftARActivity implements CraftARSea
 	private final String TAG = "ARFromCraftARActivity";
 
 	private View mScanningLayout;
-
-	CraftARSDK mCraftARSDK;
-	CraftARTracking mTracking;
-	CraftARCloudRecognition mCloudIR;
+    
+	private CraftARSDK mCraftARSDK;
+    private CraftARTracking mTracking;
+    private CraftARCloudRecognition mCloudIR;
 
 	@Override
 	public void onPostCreate() {

--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARProgrammaticallyActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/ARProgrammaticallyActivity.java
@@ -49,9 +49,9 @@ public class ARProgrammaticallyActivity extends CraftARActivity implements Craft
 
 	private View mScanningLayout;
 
-	CraftARSDK mCraftARSDK;
-	CraftARTracking mTracking;
-	CraftARCloudRecognition mCloudIR;
+	private CraftARSDK mCraftARSDK;
+	private CraftARTracking mTracking;
+	private CraftARCloudRecognition mCloudIR;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/OnDeviceARActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/OnDeviceARActivity.java
@@ -42,10 +42,10 @@ public class OnDeviceARActivity extends CraftARActivity {
 
 	private final String TAG = "OnDeviceARActivity";
 
-	CraftARTracking mTracking;
-	CraftARSDK mCraftARSDK;
-    CraftAROnDeviceCollectionManager mCollectionManager;
-    CraftAROnDeviceCollection mCollection;
+    private CraftARTracking mTracking;
+    private CraftARSDK mCraftARSDK;
+    private CraftAROnDeviceCollectionManager mCollectionManager;
+    private CraftAROnDeviceCollection mCollection;
     private Toast mToast;
     private View mScanningLayout;
 

--- a/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/RecognitionOnlyActivity.java
+++ b/craftarexampleandroid/src/main/java/com/catchoom/craftarsdkexamples/RecognitionOnlyActivity.java
@@ -50,9 +50,9 @@ public class RecognitionOnlyActivity extends CraftARActivity implements CraftARS
 	private View mTapToScanLayout;
 
 
-	CraftARTracking mTracking;
-	CraftARSDK mCraftARSDK;
-	CraftARCloudRecognition mCloudIR;
+	private CraftARTracking mTracking;
+	private CraftARSDK mCraftARSDK;
+	private CraftARCloudRecognition mCloudIR;
 
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat